### PR TITLE
fix the typo on RO:00002407 to RO:0002407

### DIFF
--- a/src/@noctua.form/data/vpe-decision.json
+++ b/src/@noctua.form/data/vpe-decision.json
@@ -93,7 +93,7 @@
           "edge": "RO:0002629"
         },
         "directness:indirect": {
-          "edge": "RO:00002407"
+          "edge": "RO:0002407"
         }
       },
       "effectDirection:negative": {

--- a/src/@noctua.form/data/vpe-decision.yaml
+++ b/src/@noctua.form/data/vpe-decision.yaml
@@ -16,7 +16,7 @@ decisionTree:
       directness:direct:
         edge: RO:0002629
       directness:indirect:
-        edge: RO:00002407
+        edge: RO:0002407
     effectDirection:negative:
       directness:direct:
         edge: RO:0002630

--- a/src/@noctua.form/noctua-form-config.ts
+++ b/src/@noctua.form/noctua-form-config.ts
@@ -109,7 +109,7 @@ const edge = {
     label: 'directly negatively regulates'
   },
   indirectlyPositivelyRegulates: {
-    id: 'RO:00002407',
+    id: 'RO:0002407',
     label: 'indirectly positively regulates'
   },
   indirectlyNegativelyRegulates: {

--- a/src/environments/environment-data.ts
+++ b/src/environments/environment-data.ts
@@ -1784,7 +1784,7 @@ export const globalKnownRelations = [
     "relevant": true
   },
   {
-    "id": "RO:00002407",
+    "id": "RO:0002407",
     "label": "indirectly positively regulates",
     "relevant": false
   },

--- a/workbenches/noctua-visual-pathway-editor/public/inject.tmpl
+++ b/workbenches/noctua-visual-pathway-editor/public/inject.tmpl
@@ -214,6 +214,6 @@
     </div>
   </noctua-splash-screen>
   <noctua-root></noctua-root>
-<script src="runtime.38b1f495cb4cd82a.js" type="module"></script><script src="polyfills.a39db01cea6f891e.js" type="module"></script><script src="scripts.79b3808e7d5e20c8.js" defer></script><script src="main.8fa71c09a72e3b16.js" type="module"></script>
+<script src="runtime.38b1f495cb4cd82a.js" type="module"></script><script src="polyfills.a39db01cea6f891e.js" type="module"></script><script src="scripts.79b3808e7d5e20c8.js" defer></script><script src="main.a2ea74ae7015676c.js" type="module"></script>
 
 </body></html>


### PR DESCRIPTION
### Issue
https://github.com/geneontology/noctua-visual-pathway-editor/issues/48#issuecomment-1405678366

### Changes
- Fix the typo for indirectly positively regulates 

tagging @vanaukenk @kltm  Thanks @balhoff for finding the error 