### PR TITLE
Hide irrelevant menu items in evidence editor dropdown

### DIFF
--- a/src/@noctua.editor/inline-editor/editor-dropdown/editor-dropdown.component.html
+++ b/src/@noctua.editor/inline-editor/editor-dropdown/editor-dropdown.component.html
@@ -139,7 +139,7 @@
     }
   </ng-container>
   }
-  @if (category === EditorCategory.all || category === EditorCategory.evidenceAll) {
+  @if (category === EditorCategory.all) {
   <button mat-icon-button class="noc-action-button" fxFlex="40px" [matMenuTriggerFor]="entityMenu">
     <mat-icon>more_vert</mat-icon>
   </button>
@@ -158,7 +158,7 @@
     </button>
     }
     @if (entity.aspect) {
-    <!--  <button mat-menu-item class="" (click)="addEvidenceISS()">
+    <!-- <button mat-menu-item class="" (click)="addEvidenceISS()">
       Add ISS Evidence
     </button> -->
     }


### PR DESCRIPTION
### Issues

- https://github.com/geneontology/noctua-visual-pathway-editor/issues/202

### Changes
- Hide "Search Annotations" menu item when editing evidence (evidenceAll category)
- Hide "Fill with root term" menu item when editing evidence (evidenceAll category)
- Only show the more menu button for all and evidenceAll editor categories

### Tests

- [ ] Open evidence editor dropdown, verify "Search Annotations" is not shown
- [ ] Open evidence editor dropdown, verify "Fill with root term" is not shown
- [ ] Open term editor (all category), verify menu items are still visible

cc @pgaudet @vanaukenk @kltm @thomaspd