### PR TITLE
Improve error messages, fix molecule uuid, refactor validation model (#184)

### DIFF
--- a/.plans/feature/error-message-improvements.md
+++ b/.plans/feature/error-message-improvements.md
@@ -1,4 +1,4 @@
-# Task: Improve error messages and fix molecule uuid for diffEdges matching
+# Task: Improve error messages, fix molecule uuid, refactor validation model
 
 **Status:** ACTIVE
 **Issue:** #184
@@ -6,7 +6,11 @@
 
 ## Goal
 
-Inter-activity/molecule edges leak into `diffEdges` because `graphToMolecules` doesn't set `activity.uuid`, causing the causal relation triple IDs to not match raw triple IDs in `setDiffs()`. Fix the root cause and rename error labels.
+1. Fix inter-activity/molecule edges leaking into diff errors (missing `activity.uuid` in `graphToMolecules`)
+2. Rename error labels to be more descriptive
+3. Align error panel UI with site theme and standard drawer pattern
+4. Refactor scattered error properties into a unified `CamValidationErrors` class
+5. Split orphaned nodes into "Node not shown" vs "Node/relation combination not allowed" to eliminate duplication
 
 ## Context
 
@@ -15,47 +19,60 @@ Inter-activity/molecule edges leak into `diffEdges` because `graphToMolecules` d
 
 ## Current State
 
-- What works now: `getCausalRelations()` correctly captures inter-activity edges. `setDiffs()` tries to exclude them via `existingTripleUuids`.
-- What's broken: `generateTripleId()` uses `subject?.uuid` to build IDs. In `graphToActivities` (line 546), `activity.uuid = bbopSubjectId` is set. In `graphToMolecules` (line 584-585), `activity.uuid` is **never set** — only `activity.id`. So when `getCausalRelations` builds `Triple<Activity>` involving molecules, the triple ID uses `undefined` for the molecule's uuid, producing IDs like `_RO:0002233_xxx` instead of `nodeId_RO:0002233_xxx`. These don't match the raw triple IDs in `setDiffs`, so the edges aren't excluded from `diffEdges`.
+All phases complete. Pending manual test and commit.
 
 ## Steps
 
-### Phase 1: Set `activity.uuid` in `graphToMolecules`
+### Phase 1: Fix `activity.uuid` in `graphToMolecules` — Done
 
-- [ ] In `src/@noctua.form/services/graph.service.ts` `graphToMolecules()`, add `activity.uuid = bbopNode.id()` after line 585 (`activity.id = bbopNode.id()`), matching the pattern in `graphToActivities` at line 546.
+- [x] In `graph.service.ts` `graphToMolecules()`, added `activity.uuid = bbopNode.id()` after `activity.id = bbopNode.id()`, matching the pattern in `graphToActivities`. This makes molecule `Triple<Activity>` IDs match raw `Triple<ActivityNode>` IDs so `setDiffs()` correctly excludes inter-activity/molecule edges.
 
-### Phase 2: Rename labels
+### Phase 2: Rename labels — Done
 
-- [ ] Toolbar chip (`src/app/main/apps/noctua-form/cam/cam-toolbar/cam-toolbar.component.html` line 20-22): `"{{cam.totalErrors}} Error(s) Found"` → `"{{cam.totalErrors}} Data model violation errors (ShEx)"`
-- [ ] Right panel summary stats (`src/app/main/apps/noctua-graph/cam-errors/cam-errors.component.html`):
-  - Line 33: `"Total Errors"` → `"Data model violation errors (ShEx)"`
-  - Line 37: `"Node Errors"` → `"Activity Units / Chemicals errors"`
-  - Line 41: `"Relation Errors"` → `"Relations errors"`
-- [ ] Right panel section headers (same file):
-  - Line 101: `"Nodes"` → `"Activity Units / Chemicals errors"`
-  - Line 119: `"Edges"` → `"Relations errors"`
-- [ ] Dialog titles:
-  - `src/app/main/apps/noctua-form/dialogs/cam-errors/cam-errors.component.html` line 5: `"Violations"` → `"Data model violation errors (ShEx)"`
-  - `src/app/main/apps/noctua-form/dialogs/activity-errors/activity-errors.component.html` line 5: `"Errors"` → `"Data model violation errors (ShEx)"`
+- [x] Right panel summary stats: "Total Errors" → "Data model violation errors (ShEx)", "Node Errors" → "Activity Units / Chemicals errors", "Relation Errors" → "Relations errors"
+- [x] Right panel section headers renamed to match
+- [x] Toolbar chip text kept as original `"{{cam.totalErrors}} Error(s) Found"` (user decision)
+- [x] Dialog titles kept as original "Violations" / "Errors" (user reverted changes)
 
-### Phase 3: Add subcategory labels
+### Phase 3: UI improvements — Done
 
-- [ ] In right panel (`cam-errors.component.html`): add `<div class="annotations__subcategory">Node/relation combination not allowed</div>` after the "Activity Units / Chemicals errors" and "Relations errors" section headers
-- [ ] Add `.annotations__subcategory` style in `cam-errors.component.scss`
+- [x] Error panel header changed from custom blue Material header to standard `noc-drawer` / `noc-drawer-header` pattern (white bg, 40px, elevation-2, stroked close button) matching all other right-panel drawers
+- [x] Added `@import "@noctua.common/scss/noctua.common"` to cam-errors SCSS (was missing — caused header styles not to apply)
+- [x] Replaced generic Material color variables with Noctua theme colors (`$noc-primary-color`, `$noc-secondary-color`, `$noc-primary-color-accent`, etc.)
+- [x] Toolbar error chip uses `noc-table-chip` class for consistent sizing, color-coded green/red via `noc-has-errors` class
+- [x] Added `.annotations__subcategory` style for section descriptions
 
-### Phase 4: Verify
+### Phase 4: Refactor validation model — Done
 
-- [ ] `npm run build` — no compilation errors
-- [ ] Manual test: load a CAM model with molecules, confirm inter-activity/molecule edges no longer inflate error count
+- [x] Created `CamValidationErrors` class in `cam.ts` grouping:
+  - `shexViolations: ActivityError[]` (was untyped `errors = []`)
+  - `orphanedNodes: ActivityNode[]` (was `diffNodes`)
+  - `orphanedEdges: Triple<ActivityNode>[]` (was `diffEdges`)
+  - Derived getters: `total`, `hasErrors`
+- [x] Replaced five scattered properties on `Cam` (`errors`, `diffNodes`, `diffEdges`, `hasViolations`, `totalErrors`) with single `validationErrors: CamValidationErrors`
+- [x] `totalErrors` getter now delegates to `validationErrors.total`
+- [x] Typed `getViolationDisplayErrors()` return as `ActivityError[]`; fixed base `Violation.getDisplayError()` return type
+- [x] Updated all consumers: `graph.service.ts`, cam-errors template, cam-toolbar template
+
+### Phase 5: Split orphaned nodes by context — Done
+
+- [x] Added `standaloneNodes` getter on `CamValidationErrors` — orphaned nodes NOT referenced by any orphaned edge (pure standalone, "Node not shown")
+- [x] Added `relationNodes` getter — orphaned nodes that ARE subject/object of an orphaned edge ("Node/relation combination not allowed")
+- [x] Template splits "Activity Units / Chemicals errors" section into two subsections, each conditionally rendered
+
+### Phase 6: Verify
+
+- [ ] Manual test: load a CAM model, verify error counts and categories are correct
+- [ ] Commit
 
 ## Recovery Checkpoint
 
 > **⚠ UPDATE THIS AFTER EVERY CHANGE**
 
-- **Last completed action:** All phases complete, build passes
+- **Last completed action:** Phase 5 — split orphaned nodes into standalone vs relation nodes
 - **Next immediate action:** Manual test / commit
-- **Recent commands run:** `npm run build` — success
-- **Uncommitted changes:** graph.service.ts, cam-toolbar.component.html, cam-errors (graph + form dialogs), cam-errors.component.scss
+- **Recent commands run:** `npm run build` — success (multiple times during development)
+- **Uncommitted changes:** cam.ts, graph.service.ts, violation-error.ts, cam-toolbar (.html/.scss), cam-errors graph panel (.html/.scss), cam-errors dialog (.html), activity-errors dialog (.html)
 - **Environment state:** branch noctua-184-error-message
 
 ## Failed Approaches
@@ -65,17 +82,21 @@ Inter-activity/molecule edges leak into `diffEdges` because `graphToMolecules` d
 | Filter in `generateViolation()` (ShEx layer) | Wrong root cause — issue is in setDiffs/diffEdges not ShEx | 2026-03-26 |
 | Create `allowedViolationPredicateIds` constant | Unnecessary — root cause is missing uuid on molecule activities | 2026-03-26 |
 | Filter by activityRootIds in setDiffs | Workaround, not fix — getCausalRelations already handles it, just IDs don't match | 2026-03-26 |
+| Filter by `noctuaFormConfig.moleculeEdges` predicate IDs | Unnecessary — same as above | 2026-03-26 |
 
 ## Files Modified
 
 | File | Action | Status |
 | ---- | ------ | ------ |
-| `src/@noctua.form/services/graph.service.ts` | Add `activity.uuid = bbopNode.id()` in `graphToMolecules()` after line 585 | Done |
-| `src/app/main/apps/noctua-form/cam/cam-toolbar/cam-toolbar.component.html` | Update chip label | Done |
-| `src/app/main/apps/noctua-graph/cam-errors/cam-errors.component.html` | Rename stats, sections, add subcategories | Done |
-| `src/app/main/apps/noctua-graph/cam-errors/cam-errors.component.scss` | Add subcategory style | Done |
-| `src/app/main/apps/noctua-form/dialogs/cam-errors/cam-errors.component.html` | Rename dialog title | Done |
-| `src/app/main/apps/noctua-form/dialogs/activity-errors/activity-errors.component.html` | Rename dialog title | Done |
+| `src/@noctua.form/models/activity/cam.ts` | Created `CamValidationErrors` class; replaced scattered props with `validationErrors`; added `standaloneNodes`/`relationNodes` getters; typed `getViolationDisplayErrors()` | Done |
+| `src/@noctua.form/models/activity/error/violation-error.ts` | Fixed `getDisplayError()` base return type to `ActivityError` | Done |
+| `src/@noctua.form/services/graph.service.ts` | Added `activity.uuid = bbopNode.id()` in `graphToMolecules()`; updated `loadCam` to use `validationErrors.shexViolations`; removed `cam.hasViolations` assignment | Done |
+| `src/app/main/apps/noctua-form/cam/cam-toolbar/cam-toolbar.component.html` | Chip uses `noc-table-chip`, `noc-validation-chip`, color-coded `noc-has-errors`; text kept as original | Done |
+| `src/app/main/apps/noctua-form/cam/cam-toolbar/cam-toolbar.component.scss` | Added `.noc-validation-chip` styles with green/red states | Done |
+| `src/app/main/apps/noctua-graph/cam-errors/cam-errors.component.html` | Standard `noc-drawer-header`; renamed labels; uses `validationErrors.*`; split nodes into standalone/relation subsections | Done |
+| `src/app/main/apps/noctua-graph/cam-errors/cam-errors.component.scss` | Added `noctua.common` import; Noctua theme colors; subcategory style; removed custom header styles | Done |
+| `src/app/main/apps/noctua-form/dialogs/cam-errors/cam-errors.component.html` | Title kept as "Violations" (user reverted) | Done |
+| `src/app/main/apps/noctua-form/dialogs/activity-errors/activity-errors.component.html` | Title kept as "Errors" (user reverted) | Done |
 
 ## Blockers
 
@@ -83,6 +104,7 @@ Inter-activity/molecule edges leak into `diffEdges` because `graphToMolecules` d
 
 ## Notes
 
-- The one-line fix (`activity.uuid = bbopNode.id()`) makes molecule `Triple<Activity>` IDs match raw `Triple<ActivityNode>` IDs, so `setDiffs` correctly excludes them via the existing `existingTripleUuids` check
-- No new constants, config changes, or filter logic needed
-- `cam.totalErrors` automatically reflects the fix since it sums `errors.length + diffEdges.length + diffNodes.length`
+- `violations: Violation[]` stays on Cam as internal plumbing for `setViolations()` propagation to activities
+- `activity.hasViolations` on the Activity class is unchanged — separate from `Cam.validationErrors`
+- Dialog titles were reverted by user to original "Violations" / "Errors"
+- Toolbar chip text was kept as original per user request

--- a/.plans/feature/error-message-improvements.md
+++ b/.plans/feature/error-message-improvements.md
@@ -1,0 +1,88 @@
+# Task: Improve error messages and fix molecule uuid for diffEdges matching
+
+**Status:** ACTIVE
+**Issue:** #184
+**Branch:** noctua-184-error-message
+
+## Goal
+
+Inter-activity/molecule edges leak into `diffEdges` because `graphToMolecules` doesn't set `activity.uuid`, causing the causal relation triple IDs to not match raw triple IDs in `setDiffs()`. Fix the root cause and rename error labels.
+
+## Context
+
+- **Related files:** see Files Modified table below
+- **Triggered by:** Issue #184
+
+## Current State
+
+- What works now: `getCausalRelations()` correctly captures inter-activity edges. `setDiffs()` tries to exclude them via `existingTripleUuids`.
+- What's broken: `generateTripleId()` uses `subject?.uuid` to build IDs. In `graphToActivities` (line 546), `activity.uuid = bbopSubjectId` is set. In `graphToMolecules` (line 584-585), `activity.uuid` is **never set** — only `activity.id`. So when `getCausalRelations` builds `Triple<Activity>` involving molecules, the triple ID uses `undefined` for the molecule's uuid, producing IDs like `_RO:0002233_xxx` instead of `nodeId_RO:0002233_xxx`. These don't match the raw triple IDs in `setDiffs`, so the edges aren't excluded from `diffEdges`.
+
+## Steps
+
+### Phase 1: Set `activity.uuid` in `graphToMolecules`
+
+- [ ] In `src/@noctua.form/services/graph.service.ts` `graphToMolecules()`, add `activity.uuid = bbopNode.id()` after line 585 (`activity.id = bbopNode.id()`), matching the pattern in `graphToActivities` at line 546.
+
+### Phase 2: Rename labels
+
+- [ ] Toolbar chip (`src/app/main/apps/noctua-form/cam/cam-toolbar/cam-toolbar.component.html` line 20-22): `"{{cam.totalErrors}} Error(s) Found"` → `"{{cam.totalErrors}} Data model violation errors (ShEx)"`
+- [ ] Right panel summary stats (`src/app/main/apps/noctua-graph/cam-errors/cam-errors.component.html`):
+  - Line 33: `"Total Errors"` → `"Data model violation errors (ShEx)"`
+  - Line 37: `"Node Errors"` → `"Activity Units / Chemicals errors"`
+  - Line 41: `"Relation Errors"` → `"Relations errors"`
+- [ ] Right panel section headers (same file):
+  - Line 101: `"Nodes"` → `"Activity Units / Chemicals errors"`
+  - Line 119: `"Edges"` → `"Relations errors"`
+- [ ] Dialog titles:
+  - `src/app/main/apps/noctua-form/dialogs/cam-errors/cam-errors.component.html` line 5: `"Violations"` → `"Data model violation errors (ShEx)"`
+  - `src/app/main/apps/noctua-form/dialogs/activity-errors/activity-errors.component.html` line 5: `"Errors"` → `"Data model violation errors (ShEx)"`
+
+### Phase 3: Add subcategory labels
+
+- [ ] In right panel (`cam-errors.component.html`): add `<div class="annotations__subcategory">Node/relation combination not allowed</div>` after the "Activity Units / Chemicals errors" and "Relations errors" section headers
+- [ ] Add `.annotations__subcategory` style in `cam-errors.component.scss`
+
+### Phase 4: Verify
+
+- [ ] `npm run build` — no compilation errors
+- [ ] Manual test: load a CAM model with molecules, confirm inter-activity/molecule edges no longer inflate error count
+
+## Recovery Checkpoint
+
+> **⚠ UPDATE THIS AFTER EVERY CHANGE**
+
+- **Last completed action:** All phases complete, build passes
+- **Next immediate action:** Manual test / commit
+- **Recent commands run:** `npm run build` — success
+- **Uncommitted changes:** graph.service.ts, cam-toolbar.component.html, cam-errors (graph + form dialogs), cam-errors.component.scss
+- **Environment state:** branch noctua-184-error-message
+
+## Failed Approaches
+
+| What was tried | Why it failed | Date |
+| -------------- | ------------- | ---- |
+| Filter in `generateViolation()` (ShEx layer) | Wrong root cause — issue is in setDiffs/diffEdges not ShEx | 2026-03-26 |
+| Create `allowedViolationPredicateIds` constant | Unnecessary — root cause is missing uuid on molecule activities | 2026-03-26 |
+| Filter by activityRootIds in setDiffs | Workaround, not fix — getCausalRelations already handles it, just IDs don't match | 2026-03-26 |
+
+## Files Modified
+
+| File | Action | Status |
+| ---- | ------ | ------ |
+| `src/@noctua.form/services/graph.service.ts` | Add `activity.uuid = bbopNode.id()` in `graphToMolecules()` after line 585 | Done |
+| `src/app/main/apps/noctua-form/cam/cam-toolbar/cam-toolbar.component.html` | Update chip label | Done |
+| `src/app/main/apps/noctua-graph/cam-errors/cam-errors.component.html` | Rename stats, sections, add subcategories | Done |
+| `src/app/main/apps/noctua-graph/cam-errors/cam-errors.component.scss` | Add subcategory style | Done |
+| `src/app/main/apps/noctua-form/dialogs/cam-errors/cam-errors.component.html` | Rename dialog title | Done |
+| `src/app/main/apps/noctua-form/dialogs/activity-errors/activity-errors.component.html` | Rename dialog title | Done |
+
+## Blockers
+
+- None currently
+
+## Notes
+
+- The one-line fix (`activity.uuid = bbopNode.id()`) makes molecule `Triple<Activity>` IDs match raw `Triple<ActivityNode>` IDs, so `setDiffs` correctly excludes them via the existing `existingTripleUuids` check
+- No new constants, config changes, or filter logic needed
+- `cam.totalErrors` automatically reflects the fix since it sums `errors.length + diffEdges.length + diffNodes.length`

--- a/src/@noctua.form/models/activity/cam.ts
+++ b/src/@noctua.form/models/activity/cam.ts
@@ -129,6 +129,24 @@ export class CamValidationErrors {
   get hasErrors(): boolean {
     return this.total > 0;
   }
+
+  get standaloneNodes(): ActivityNode[] {
+    const edgeNodeUuids = new Set<string>();
+    this.orphanedEdges.forEach((triple: Triple<ActivityNode>) => {
+      if (triple.subject?.uuid) edgeNodeUuids.add(triple.subject.uuid);
+      if (triple.object?.uuid) edgeNodeUuids.add(triple.object.uuid);
+    });
+    return this.orphanedNodes.filter((node: ActivityNode) => !edgeNodeUuids.has(node.uuid));
+  }
+
+  get relationNodes(): ActivityNode[] {
+    const edgeNodeUuids = new Set<string>();
+    this.orphanedEdges.forEach((triple: Triple<ActivityNode>) => {
+      if (triple.subject?.uuid) edgeNodeUuids.add(triple.subject.uuid);
+      if (triple.object?.uuid) edgeNodeUuids.add(triple.object.uuid);
+    });
+    return this.orphanedNodes.filter((node: ActivityNode) => edgeNodeUuids.has(node.uuid));
+  }
 }
 
 export class Cam {

--- a/src/@noctua.form/models/activity/cam.ts
+++ b/src/@noctua.form/models/activity/cam.ts
@@ -9,6 +9,7 @@ import { Entity } from './entity';
 import { each, find, orderBy } from 'lodash';
 import { NoctuaFormUtils } from './../../utils/noctua-form-utils';
 import { Violation } from './error/violation-error';
+import { ActivityError } from './parser/activity-error';
 import { PendingChange } from './pending-change';
 
 export enum ReloadType {
@@ -116,6 +117,20 @@ export class CamRebuildRule {
   }
 }
 
+export class CamValidationErrors {
+  shexViolations: ActivityError[] = [];
+  orphanedNodes: ActivityNode[] = [];
+  orphanedEdges: Triple<ActivityNode>[] = [];
+
+  get total(): number {
+    return this.shexViolations.length + this.orphanedNodes.length + this.orphanedEdges.length;
+  }
+
+  get hasErrors(): boolean {
+    return this.total > 0;
+  }
+}
+
 export class Cam {
   title: string;
   comments: string[] = [];
@@ -172,9 +187,8 @@ export class Cam {
 
   // Error Handling
   isReasoned = false;
-  hasViolations = false;
   violations: Violation[] = [];
-  errors = [];
+  validationErrors = new CamValidationErrors();
 
   //Graph
   manualLayout = false;
@@ -184,9 +198,6 @@ export class Cam {
   private _activities: Activity[] = [];
   private _storedActivities: Activity[] = [];
   private _id: string;
-
-  diffNodes: ActivityNode[] = [];
-  diffEdges: Triple<ActivityNode>[] = [];
 
   //raw data
   rawTriples: Triple<ActivityNode>[];
@@ -221,7 +232,7 @@ export class Cam {
   }
 
   get totalErrors() {
-    return this.errors.length + this.diffEdges.length + this.diffNodes.length;
+    return this.validationErrors.total;
   }
 
   set activities(srcActivities: Activity[]) {
@@ -271,9 +282,9 @@ export class Cam {
       existingTripleUuids.add(triple.id);
     });
 
-    this.diffNodes = nodes.filter((node: ActivityNode) => !existingNodeUuids.has(node.uuid));
+    this.validationErrors.orphanedNodes = nodes.filter((node: ActivityNode) => !existingNodeUuids.has(node.uuid));
 
-    this.diffEdges = triples.filter((triple: Triple<ActivityNode>) => !existingTripleUuids.has(triple.id));
+    this.validationErrors.orphanedEdges = triples.filter((triple: Triple<ActivityNode>) => !existingTripleUuids.has(triple.id));
 
   }
 
@@ -477,14 +488,10 @@ export class Cam {
     });
   }
 
-  getViolationDisplayErrors() {
-    const result = [];
-
-    result.push(...this.violations.map((violation: Violation) => {
+  getViolationDisplayErrors(): ActivityError[] {
+    return this.violations.map((violation: Violation) => {
       return violation.getDisplayError();
-    }));
-
-    return result;
+    });
   }
 
   tableCanDisplayEnabledBy(node: ActivityNode) {

--- a/src/@noctua.form/models/activity/error/violation-error.ts
+++ b/src/@noctua.form/models/activity/error/violation-error.ts
@@ -10,7 +10,7 @@ export class Violation {
   constructor(public node: Partial<ActivityNode>, public type: ViolationType) {
   }
 
-  getDisplayError() { }
+  getDisplayError(): ActivityError { return null; }
 
   get message() {
     return this._message;

--- a/src/@noctua.form/services/graph.service.ts
+++ b/src/@noctua.form/services/graph.service.ts
@@ -238,7 +238,7 @@ export class NoctuaGraphService {
   loadCam(cam: Cam, publish = true) {
     const activities = this.graphToActivities(cam.graph);
 
-    cam.errors = cam.getViolationDisplayErrors();
+    cam.validationErrors.shexViolations = cam.getViolationDisplayErrors();
 
     if (environment.isGraph) {
       const molecules = this.graphToMolecules(cam.graph);
@@ -291,7 +291,7 @@ export class NoctuaGraphService {
       validationResults['shex-validation'] &&
       validationResults['shex-validation']['violations']) {
       violations = validationResults['shex-validation']['violations'];
-      cam.hasViolations = violations.length > 0;
+      // hasViolations is now derived from cam.validationErrors.hasErrors
       cam.violations = [];
       violations.forEach((violation: any) => {
         violation.explanations.forEach((explanation) => {

--- a/src/@noctua.form/services/graph.service.ts
+++ b/src/@noctua.form/services/graph.service.ts
@@ -583,6 +583,7 @@ export class NoctuaGraphService {
           subjectActivityNode.classExpression = subjectNode.classExpression;
           subjectActivityNode.uuid = bbopNode.id();
           activity.id = bbopNode.id();
+          activity.uuid = bbopNode.id();
           self._graphToActivityDFS(camGraph, activity, subjectEdges, subjectActivityNode);
           //activity.postRunUpdate();
           activities.push(activity);

--- a/src/app/main/apps/noctua-form/cam/cam-toolbar/cam-toolbar.component.html
+++ b/src/app/main/apps/noctua-form/cam/cam-toolbar/cam-toolbar.component.html
@@ -11,9 +11,10 @@
     </div>
   </div>
   }
-  <!--   <div class="noc-error" fxLayout="row" fxLayoutAlign="start center">
-    <mat-chip class="noc-error-chip noc-chip-xs ml-8" fxLayout="row" fxLayoutAlign="start center"
-      (click)="openCamErrors()">
+  <div class="noc-error" fxLayout="row" fxLayoutAlign="start center">
+    <mat-chip class="noc-table-chip noc-validation-chip ml-8" fxLayout="row" fxLayoutAlign="start center"
+      (click)="openCamErrors()"
+      [ngClass]="{'noc-has-errors': cam.totalErrors > 0}">
       <div class="noc-icon">
         <fa-icon [icon]="['fas', 'exclamation-triangle']"></fa-icon>
       </div>
@@ -21,7 +22,7 @@
         {{cam.totalErrors}} Error(s) Found
       </div>
     </mat-chip>
-  </div> -->
+  </div>
   <div class="noc-br noc-bl px-4">
     <button mat-icon-button class="noc-toolbar-button noc-rounded-button" (click)="openCamForm()"
       matTooltip="{{cam?.comments}}" [matTooltipPosition]="'after'" [matTooltipShowDelay]="1000">

--- a/src/app/main/apps/noctua-form/cam/cam-toolbar/cam-toolbar.component.scss
+++ b/src/app/main/apps/noctua-form/cam/cam-toolbar/cam-toolbar.component.scss
@@ -169,6 +169,23 @@ $accent: map-get($theme, accent);
         @include noc-chip-color(#aee9f5);
       }
 
+      &.noc-validation-chip {
+        @include noc-chip-color(#b6d4b6);
+        cursor: pointer;
+
+        .noc-icon {
+          color: #4caf50;
+        }
+
+        &.noc-has-errors {
+          @include noc-chip-color(#e8a0a0);
+
+          .noc-icon {
+            color: #fff;
+          }
+        }
+      }
+
       &.noc-state-chip {
         &.noc-development {
           @include noc-chip-color(#f4c89c);

--- a/src/app/main/apps/noctua-graph/cam-errors/cam-errors.component.html
+++ b/src/app/main/apps/noctua-graph/cam-errors/cam-errors.component.html
@@ -79,25 +79,55 @@
 
     <!-- Annotations -->
     <div class="annotations" fxLayout="column">
-      <!-- Nodes Section -->
+      <!-- Activity Units / Chemicals errors -->
       <div class="annotations__section">
         <div class="annotations__header" fxLayout="row" fxLayoutAlign="start center">
           <mat-icon class="annotations__icon">account_tree</mat-icon>
           <h3 class="annotations__title">Activity Units / Chemicals errors</h3>
           <span class="annotations__count">{{ cam.validationErrors.orphanedNodes.length }}</span>
         </div>
-        <div class="annotations__subcategory">Node/relation combination not allowed</div>
-        <div class="annotations__list">
-          @for (node of cam.validationErrors.orphanedNodes; track node) {
-          <div class="annotation-item" fxLayout="row" fxLayoutAlign="start center">
-            <div class="annotation-item__id">{{ node.id }}</div>
-            <div class="annotation-item__content" fxFlex>
-              <div class="annotation-item__label">{{ node.term?.label }}</div>
-              <div class="annotation-item__term-id">{{ node.term?.id }}</div>
-            </div>
+
+        @if (cam.validationErrors.standaloneNodes.length > 0) {
+        <div class="annotations__subsection">
+          <div class="annotations__subheader" fxLayout="row" fxLayoutAlign="start center">
+            <mat-icon class="annotations__subicon">visibility_off</mat-icon>
+            <h4 class="annotations__subtitle">Node not shown</h4>
+            <span class="annotations__count">{{ cam.validationErrors.standaloneNodes.length }}</span>
           </div>
-          }
+          <div class="annotations__list">
+            @for (node of cam.validationErrors.standaloneNodes; track node) {
+            <div class="annotation-item" fxLayout="row" fxLayoutAlign="start center">
+              <div class="annotation-item__id">{{ node.id }}</div>
+              <div class="annotation-item__content" fxFlex>
+                <div class="annotation-item__label">{{ node.term?.label }}</div>
+                <div class="annotation-item__term-id">{{ node.term?.id }}</div>
+              </div>
+            </div>
+            }
+          </div>
         </div>
+        }
+
+        @if (cam.validationErrors.relationNodes.length > 0) {
+        <div class="annotations__subsection">
+          <div class="annotations__subheader" fxLayout="row" fxLayoutAlign="start center">
+            <mat-icon class="annotations__subicon">block</mat-icon>
+            <h4 class="annotations__subtitle">Node/relation combination not allowed</h4>
+            <span class="annotations__count">{{ cam.validationErrors.relationNodes.length }}</span>
+          </div>
+          <div class="annotations__list">
+            @for (node of cam.validationErrors.relationNodes; track node) {
+            <div class="annotation-item" fxLayout="row" fxLayoutAlign="start center">
+              <div class="annotation-item__id">{{ node.id }}</div>
+              <div class="annotation-item__content" fxFlex>
+                <div class="annotation-item__label">{{ node.term?.label }}</div>
+                <div class="annotation-item__term-id">{{ node.term?.id }}</div>
+              </div>
+            </div>
+            }
+          </div>
+        </div>
+        }
       </div>
 
       <div class="annotations__section">

--- a/src/app/main/apps/noctua-graph/cam-errors/cam-errors.component.html
+++ b/src/app/main/apps/noctua-graph/cam-errors/cam-errors.component.html
@@ -1,44 +1,29 @@
-<div class="error-drawer" fxLayout="column" fxLayoutAlign="start stretch">
+<div class="noc-drawer w-100-p h-100-p" fxLayout="column" fxLayoutAlign="start stretch">
   <!-- Header -->
-  <div class="error-drawer__header" fxLayout="row" fxLayoutAlign="space-between center">
-    <div class="error-drawer__header-content" fxLayout="row" fxLayoutAlign="start center">
-      <div class="error-drawer__header-icon">
-        <mat-icon>error_outline</mat-icon>
-      </div>
-      <div class="error-drawer__header-text">
-        <h1 class="error-drawer__header-title">Validation Errors</h1>
-      </div>
-    </div>
-    <div class="error-drawer__header-actions" fxLayout="row" fxLayoutAlign="end center">
-      <button mat-icon-button [matMenuTriggerFor]="activityOptionMenu" class="error-drawer__menu-btn">
-        <mat-icon>more_vert</mat-icon>
-      </button>
-      <mat-menu #activityOptionMenu="matMenu" class="error-drawer__dropdown">
-        <button mat-menu-item (click)="deleteActivity(activity)" class="error-drawer__delete-btn">
-          <mat-icon>delete</mat-icon>
-          Delete
-        </button>
-      </mat-menu>
-      <button mat-stroked-button (click)="close()" class="error-drawer__close-btn">
-        <mat-icon>close</mat-icon>
-        Close
-      </button>
-    </div>
+  <div class="noc-drawer-header" fxLayout="row" fxLayoutAlign="start center">
+    <span class="noc-drawer-header-title">
+      Validation Errors
+    </span>
+    <span fxFlex></span>
+    <button mat-stroked-button (click)="close()" class="noc-rounded-button noc-sm" color="primary"
+      aria-label="Close dialog">
+      <mat-icon>close</mat-icon> Close
+    </button>
   </div>
 
   <!-- Summary Stats -->
   <div class="error-drawer__summary" fxLayout="row" fxLayoutAlign="space-around center">
     <div class="error-drawer__stat error-drawer__stat--total">
       <div class="error-drawer__stat-number">{{ cam.errors.length }}</div>
-      <div class="error-drawer__stat-label">Total Errors</div>
+      <div class="error-drawer__stat-label">Data model violation errors (ShEx)</div>
     </div>
     <div class="error-drawer__stat error-drawer__stat--relation">
       <div class="error-drawer__stat-number">{{ cam.diffNodes.length }}</div>
-      <div class="error-drawer__stat-label">Node Errors</div>
+      <div class="error-drawer__stat-label">Activity Units / Chemicals errors</div>
     </div>
     <div class="error-drawer__stat error-drawer__stat--cardinality">
       <div class="error-drawer__stat-number">{{ cam.diffEdges.length }}</div>
-      <div class="error-drawer__stat-label">Relation Errors</div>
+      <div class="error-drawer__stat-label">Relations errors</div>
     </div>
   </div>
 
@@ -98,9 +83,10 @@
       <div class="annotations__section">
         <div class="annotations__header" fxLayout="row" fxLayoutAlign="start center">
           <mat-icon class="annotations__icon">account_tree</mat-icon>
-          <h3 class="annotations__title">Nodes</h3>
+          <h3 class="annotations__title">Activity Units / Chemicals errors</h3>
           <span class="annotations__count">{{ cam.diffNodes.length }}</span>
         </div>
+        <div class="annotations__subcategory">Node/relation combination not allowed</div>
         <div class="annotations__list">
           @for (node of cam.diffNodes; track node) {
           <div class="annotation-item" fxLayout="row" fxLayoutAlign="start center">
@@ -117,9 +103,10 @@
       <div class="annotations__section">
         <div class="annotations__header" fxLayout="row" fxLayoutAlign="start center">
           <mat-icon class="annotations__icon">link</mat-icon>
-          <h3 class="annotations__title">Edges</h3>
+          <h3 class="annotations__title">Relations errors</h3>
           <span class="annotations__count">{{ cam.diffEdges.length }}</span>
         </div>
+        <div class="annotations__subcategory">Node/relation combination not allowed</div>
         <div class="annotations__list">
           @for (edge of cam.diffEdges; track edge) {
           <div class="annotation-item annotation-item--edge" fxLayout="row" fxLayoutAlign="start center">

--- a/src/app/main/apps/noctua-graph/cam-errors/cam-errors.component.html
+++ b/src/app/main/apps/noctua-graph/cam-errors/cam-errors.component.html
@@ -14,15 +14,15 @@
   <!-- Summary Stats -->
   <div class="error-drawer__summary" fxLayout="row" fxLayoutAlign="space-around center">
     <div class="error-drawer__stat error-drawer__stat--total">
-      <div class="error-drawer__stat-number">{{ cam.errors.length }}</div>
+      <div class="error-drawer__stat-number">{{ cam.validationErrors.shexViolations.length }}</div>
       <div class="error-drawer__stat-label">Data model violation errors (ShEx)</div>
     </div>
     <div class="error-drawer__stat error-drawer__stat--relation">
-      <div class="error-drawer__stat-number">{{ cam.diffNodes.length }}</div>
+      <div class="error-drawer__stat-number">{{ cam.validationErrors.orphanedNodes.length }}</div>
       <div class="error-drawer__stat-label">Activity Units / Chemicals errors</div>
     </div>
     <div class="error-drawer__stat error-drawer__stat--cardinality">
-      <div class="error-drawer__stat-number">{{ cam.diffEdges.length }}</div>
+      <div class="error-drawer__stat-number">{{ cam.validationErrors.orphanedEdges.length }}</div>
       <div class="error-drawer__stat-label">Relations errors</div>
     </div>
   </div>
@@ -30,13 +30,13 @@
   <!-- Error List -->
   <div class="error-drawer__body overflow-y-auto" fxLayout="column">
     <div class="error-list">
-      @for (error of cam.errors; track error; let i = $index) {
+      @for (error of cam.validationErrors.shexViolations; track error; let i = $index) {
       <div class="error-item" fxLayout="column">
         <div class="error-item__header" fxLayout="row" fxLayoutAlign="start start">
           <div class="error-item__number">{{ i + 1 }}</div>
           <div class="error-item__content" fxFlex>
             <div class="error-item__title">
-              <span class="error-item__aspect">{{ error.meta?.aspect }}</span>: {{ error.message }}
+              {{ error.message }}
             </div>
           </div>
         </div>
@@ -84,11 +84,11 @@
         <div class="annotations__header" fxLayout="row" fxLayoutAlign="start center">
           <mat-icon class="annotations__icon">account_tree</mat-icon>
           <h3 class="annotations__title">Activity Units / Chemicals errors</h3>
-          <span class="annotations__count">{{ cam.diffNodes.length }}</span>
+          <span class="annotations__count">{{ cam.validationErrors.orphanedNodes.length }}</span>
         </div>
         <div class="annotations__subcategory">Node/relation combination not allowed</div>
         <div class="annotations__list">
-          @for (node of cam.diffNodes; track node) {
+          @for (node of cam.validationErrors.orphanedNodes; track node) {
           <div class="annotation-item" fxLayout="row" fxLayoutAlign="start center">
             <div class="annotation-item__id">{{ node.id }}</div>
             <div class="annotation-item__content" fxFlex>
@@ -104,15 +104,15 @@
         <div class="annotations__header" fxLayout="row" fxLayoutAlign="start center">
           <mat-icon class="annotations__icon">link</mat-icon>
           <h3 class="annotations__title">Relations errors</h3>
-          <span class="annotations__count">{{ cam.diffEdges.length }}</span>
+          <span class="annotations__count">{{ cam.validationErrors.orphanedEdges.length }}</span>
         </div>
         <div class="annotations__subcategory">Node/relation combination not allowed</div>
         <div class="annotations__list">
-          @for (edge of cam.diffEdges; track edge) {
+          @for (edge of cam.validationErrors.orphanedEdges; track edge) {
           <div class="annotation-item annotation-item--edge" fxLayout="row" fxLayoutAlign="start center">
             <div class="annotation-item__id annotation-item__id--edge">→</div>
             <div class="annotation-item__content" fxFlex>
-              {{ edge.subject.term?.label }} —— {{ edge.predicate?.edge.label }} ——→ {{ edge.object.term?.label }}
+              {{ edge.subject.term?.label }} —— {{ edge.predicate?.edge?.label }} ——→ {{ edge.object.term?.label }}
             </div>
           </div>
           }

--- a/src/app/main/apps/noctua-graph/cam-errors/cam-errors.component.scss
+++ b/src/app/main/apps/noctua-graph/cam-errors/cam-errors.component.scss
@@ -1,78 +1,24 @@
-// Variables
-$primary: #1976d2;
-$accent: #ff4081;
-$warn: #f44336;
-$success: #4caf50;
+@import "@noctua/scss/noctua";
+@import "@noctua.common/scss/noctua.common";
 
-$bg-primary: #fafafa;
+// Variables — aligned with Noctua theme
+$primary: $noc-primary-color;        // #3b5998
+$primary-light: $noc-primary-color-lighter; // #dfe3ee
+$accent: $noc-primary-color-accent;  // #8b9dc3
+$warn: #c0392b;
+$success: #27ae60;
+
+$bg-primary: #f5f6fa;
 $bg-secondary: #ffffff;
-$text-primary: #212121;
-$text-secondary: #757575;
-$border: #e0e0e0;
+$text-primary: #2c3e50;
+$text-secondary: #7f8c8d;
+$border: $noc-primary-color-light;
 
-$radius: 8px;
-$shadow: 0 2px 4px rgba(0, 0, 0, 0.12);
+$radius: 6px;
+$shadow: 0 1px 3px rgba(59, 89, 152, 0.12);
 
-// Main container
+// Summary
 .error-drawer {
-  height: 100vh;
-  background: $bg-primary;
-
-  // Header
-  &__header {
-    background: $primary;
-    color: white;
-    padding: 16px 24px;
-
-    &-content {
-      gap: 16px;
-    }
-
-    &-icon {
-      background: rgba(255, 255, 255, 0.2);
-      border-radius: $radius;
-      width: 40px;
-      height: 40px;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-    }
-
-    &-title {
-      font-size: 20px;
-      font-weight: 600;
-      margin: 0;
-    }
-
-    &-subtitle {
-      font-size: 14px;
-      opacity: 0.8;
-      margin: 0;
-    }
-
-    &-actions {
-      gap: 8px;
-    }
-  }
-
-  &__close-btn {
-    border: 1px solid rgba(255, 255, 255, 0.3);
-    color: white;
-
-    &:hover {
-      background: rgba(255, 255, 255, 0.1);
-    }
-  }
-
-  &__menu-btn {
-    color: white;
-
-    &:hover {
-      background: rgba(255, 255, 255, 0.1);
-    }
-  }
-
-  // Summary
   &__summary {
     background: $bg-secondary;
     padding: 16px 24px;
@@ -88,21 +34,21 @@ $shadow: 0 2px 4px rgba(0, 0, 0, 0.12);
     min-width: 100px;
 
     &--total {
-      background: #ffebee;
+      background: rgba($warn, 0.08);
       border-color: $warn;
       color: $warn;
     }
 
     &--relation {
-      background: #e3f2fd;
+      background: rgba($primary, 0.08);
       border-color: $primary;
       color: $primary;
     }
 
     &--cardinality {
-      background: #fff3e0;
-      border-color: #ff9800;
-      color: #ff9800;
+      background: rgba($noc-secondary-color, 0.08);
+      border-color: $noc-secondary-color;
+      color: $noc-secondary-color;
     }
 
     &-number {
@@ -208,14 +154,14 @@ $shadow: 0 2px 4px rgba(0, 0, 0, 0.12);
     white-space: nowrap;
 
     &--warning {
-      background: #ff9800;
+      background: $noc-secondary-color;
     }
   }
 }
 
 .cardinality-viz {
-  background: #fff8e1;
-  border: 1px solid #ff9800;
+  background: rgba($noc-secondary-color, 0.06);
+  border: 1px solid rgba($noc-secondary-color, 0.3);
 }
 
 // Annotations
@@ -238,7 +184,7 @@ $shadow: 0 2px 4px rgba(0, 0, 0, 0.12);
   }
 
   &__icon {
-    background: $success;
+    background: $primary;
     color: white;
     width: 28px;
     height: 28px;
@@ -256,12 +202,19 @@ $shadow: 0 2px 4px rgba(0, 0, 0, 0.12);
   }
 
   &__count {
-    background: #e8f5e8;
-    color: $success;
+    background: $primary-light;
+    color: $primary;
     padding: 2px 8px;
     border-radius: 12px;
     font-size: 12px;
     font-weight: 600;
+  }
+
+  &__subcategory {
+    font-size: 12px;
+    color: $text-secondary;
+    font-style: italic;
+    padding: 0 0 8px 40px;
   }
 
   &__list {
@@ -280,11 +233,11 @@ $shadow: 0 2px 4px rgba(0, 0, 0, 0.12);
 
   &:hover {
     background: $bg-secondary;
-    border-color: $success;
+    border-color: $accent;
   }
 
   &__id {
-    background: $success;
+    background: $primary;
     color: white;
     padding: 4px 8px;
     border-radius: 4px;

--- a/src/app/main/apps/noctua-graph/cam-errors/cam-errors.component.scss
+++ b/src/app/main/apps/noctua-graph/cam-errors/cam-errors.component.scss
@@ -210,11 +210,31 @@ $shadow: 0 1px 3px rgba(59, 89, 152, 0.12);
     font-weight: 600;
   }
 
-  &__subcategory {
-    font-size: 12px;
-    color: $text-secondary;
-    font-style: italic;
-    padding: 0 0 8px 40px;
+  &__subsection {
+    margin-top: 12px;
+    padding: 12px;
+    background: $bg-primary;
+    border-radius: $radius;
+    border: 1px solid $border;
+  }
+
+  &__subheader {
+    margin-bottom: 10px;
+    gap: 8px;
+  }
+
+  &__subicon {
+    color: $accent;
+    font-size: 18px;
+    width: 18px;
+    height: 18px;
+  }
+
+  &__subtitle {
+    font-size: 13px;
+    font-weight: 600;
+    color: $text-primary;
+    margin: 0;
   }
 
   &__list {


### PR DESCRIPTION
### Issues

- #184

### Changes

- Fix molecule `diffEdges` matching by setting `activity.uuid` in `graphToMolecules()` so inter-activity/molecule edges are correctly excluded
- Rename error labels to be more descriptive (e.g., "Total Errors" → "Data model violation errors (ShEx)", "Node Errors" → "Activity Units / Chemicals errors")
- Consolidate scattered error properties (`errors`, `diffNodes`, `diffEdges`, `hasViolations`, `totalErrors`) into a unified `CamValidationErrors` class
- Split orphaned nodes into "Node not shown" vs "Node/relation combination not allowed" subcategories
- Align error panel UI with site theme: standard `noc-drawer` header pattern, Noctua theme colors, color-coded validation chip in toolbar

### Tests

- [ ] Load a CAM model and verify error counts match between toolbar chip and error panel
- [ ] Verify ShEx violations, orphaned nodes, and orphaned edges display correctly in their respective sections
- [ ] Confirm orphaned nodes are correctly split into standalone vs relation subcategories
- [ ] Check that molecule edges no longer leak into diff errors
- [ ] Verify error panel header and styling matches other right-panel drawers

cc @pgaudet @vanaukenk @kltm @thomaspd