### PR TITLE
Fix BP terms appearing in cellular component lookup #226

### DIFF
--- a/src/@noctua.form/services/lookup.service.ts
+++ b/src/@noctua.form/services/lookup.service.ts
@@ -144,8 +144,8 @@ export class NoctuaLookupService {
     ];
 
     if (aspect === 'C') {
-      fqFilters.push('regulates_closure:"GO:0005575"');
-      fqFilters.push('-regulates_closure:"GO:0032991"');
+      fqFilters.push('isa_partof_closure:"GO:0005575"');
+      fqFilters.push('-isa_partof_closure:"GO:0032991"');
 
     } else {
       fqFilters.push('aspect: "' + aspect + '"');
@@ -171,17 +171,10 @@ export class NoctuaLookupService {
         'assigned_by',
         'aspect',
         'evidence_type_closure',
-        // 'panther_family_label',
-        // 'qualifier',
-        // 'taxon_label',
+        'isa_partof_closure_label',
         'annotation_class_label',
-        // 'regulates_closure_label',
-        // 'annotation_extension_class_closure_label'
       ],
       q: '*:*',
-      //  packet: '1',
-      //  callback_type: 'search',
-      // _: Date.now()
     };
 
 


### PR DESCRIPTION
### Issues

- https://github.com/geneontology/noctua-visual-pathway-editor/issues/226

### Changes

- Switched the cellular component aspect filter in `lookup.service.ts` from `regulates_closure` to `isa_partof_closure` so the GOlr query only returns terms that are CC subclasses or parts of CC, instead of any term that *regulates* CC.
- Updated the `-regulates_closure:"GO:0032991"` (protein-containing complex) exclusion to use `isa_partof_closure` for consistency with the new filter.
- Replaced commented-out fields with `isa_partof_closure_label` in the returned `fl` field set.

### Tests

- [ ] In the activity form, open the CC autocomplete and confirm BP terms (e.g. "protein insertion into ...") no longer appear.
- [ ] Confirm protein-containing complex (GO:0032991) terms are still excluded.
- [ ] Confirm legitimate CC terms still appear.

cc @pgaudet @vanaukenk @kltm @thomaspd