### PR TITLE
Allow phase/stage terms in phase-range extension fields (#259)

### DIFF
--- a/.plans/feature/phase-terms-extensions.md
+++ b/.plans/feature/phase-terms-extensions.md
@@ -1,0 +1,93 @@
+# Task: Allow biological phase/stage terms in the "happens during" extension
+
+**Status:** COMPLETE
+**Issue:** #259
+**Branch:** issue-259-phase-term
+
+## Goal
+Let biological phase/stage terms (descendants of GO:0044848 / UBERON:0000105 / PO:0009012, which carry `gocheck_do_not_annotate`) be selectable in the **happens during** extension field, while staying blocked in primary GO term fields. Mirrors the Angular `lookup.service.ts` change from noctua-standard-annotations, reimplemented the React way.
+
+## Context
+- **Related files:**
+  - `src/features/search/services/lookupServices.ts` — `mapGOlrResponse` (= Angular `_lookupMap`); GOLr response mapping + `notAnnotatable` flag
+  - `src/features/search/slices/lookupApiSlice.ts` — `searchTerms.queryFn` (= Angular `termLookup`/`search`); calls `mapGOlrResponse`
+  - `src/features/gocam/slices/camSlice.ts` — `makeSelectModelTerms` + `nodeToOption` (= Angular `termPreLookup`); on-focus prelookup options
+  - `src/features/gocam/models/cam.ts` — `RootTypes` enum (already has `BIOLOGICAL_PHASE`, `UBERON_STAGE`, `PLANT_STAGE`); home for the new `PHASE_CATEGORIES` set
+  - `src/features/gocam/data/nodeCategories.ts` — `happensDuring` range + `biologicalPhase.searchClosureIds` (drive the field's `closureIds`)
+  - `src/features/gocam/data/insertMenuConfig.ts` — `happens during` insert-menu item (targetType `BIOLOGICAL_PHASE`)
+  - `src/features/search/components/Autocomplete.tsx` — renders `notAnnotatable === false` as red/disabled
+- **Triggered by:** Port of noctua-standard-annotations issue (geneontology/noctua#1040) into the React VPE.
+
+## Current State
+- **What works now:** Searching/prelookup in a `happens during` field already passes the field's `closureIds`/`rootTypeIds` (= `['GO:0044848']`) into both the search query and `makeSelectModelTerms`. The wiring is in place.
+- **What's broken/missing:** Phase terms carry `gocheck_do_not_annotate`, so `mapGOlrResponse` marks them `notAnnotatable: false` and the Autocomplete renders them red + unclickable. The prelookup path hardcodes `notAnnotatable: true` and never distinguishes phase terms. Neither path acts on the phase category context, so phase terms cannot be picked for `happens during`.
+
+## Decisions
+- **Phase category set = all 3** stage types: `GO:0044848` (biological phase), `UBERON:0000105` (uberon/life stage), `PO:0009012` (plant stage) — matches this repo's `happensDuring` range in `nodeCategories.ts` (Angular only had the first two). Confirmed with user.
+
+## Why it stays correct
+The bypass keys on the **field's** `closureIds`, not on the term. A phase term `is_a` biological_process, so it can surface in a BP field (`closureIds: ['GO:0008150']`); there `allowNotAnnotatable` is false → it's correctly left do-not-annotate. Only a field whose closureIds include a phase category unlocks it.
+
+## Steps
+
+### Phase 1: Shared constant
+- [x] In `cam.ts`, add `export const PHASE_CATEGORIES = new Set<string>([RootTypes.BIOLOGICAL_PHASE, RootTypes.UBERON_STAGE, RootTypes.PLANT_STAGE])`
+
+### Phase 2: Type-ahead search path (= `_lookupMap` + `termLookup`)
+- [x] `mapGOlrResponse(response, closureIds?: string[])` — `const allowNotAnnotatable = closureIds?.some(id => PHASE_CATEGORIES.has(id))`; set `notAnnotatable: allowNotAnnotatable || !item.subset?.includes('gocheck_do_not_annotate')`
+- [x] In `lookupApiSlice.ts` `searchTerms.queryFn`, pass closure context: `mapGOlrResponse(response, closureIds)`
+- [x] Confirm `getChemicalParticipants` caller (no arg) is unaffected — left untouched, optional param defaults to undefined
+
+### Phase 3: Prelookup path (= `termPreLookup`)
+- [x] In `makeSelectModelTerms`, compute `const allowNotAnnotatable = rootTypeIds.some(id => PHASE_CATEGORIES.has(id))` once
+- [x] Per node: `const isPhase = node.rootTypes.some(rt => PHASE_CATEGORIES.has(rt))`; pass `notAnnotatable: allowNotAnnotatable || !isPhase` into `nodeToOption`
+- [x] Add a `notAnnotatable` parameter to `nodeToOption` (replace hardcoded `true`)
+- [x] **Did NOT touch the rootTypes-overlap filter** (see Failed Approaches)
+
+### Phase 4: Verify
+- [x] `npm run type-check` — passes
+- [x] `npx eslint` on the 4 changed files — passes clean
+- [ ] Phase terms appear + are selectable in `happens during` type-ahead (manual / runtime)
+- [ ] Phase terms appear + selectable in `happens during` prelookup (on focus) (manual / runtime)
+- [ ] Phase terms remain blocked (red) in the primary BP term field (manual / runtime)
+- [ ] Non-phase relations (e.g. `has input`) still block do-not-annotate terms (manual / runtime)
+
+## Recovery Checkpoint
+
+> **⚠ UPDATE THIS AFTER EVERY CHANGE**
+
+- **Last completed action:** ✅ TASK COMPLETE — all 4 edits made; type-check + eslint pass
+- **Next immediate action:** Runtime verification in the app (the 4 unchecked manual checks)
+- **Recent commands run:**
+  - `npm run type-check` (pass)
+  - `npx eslint <4 changed files>` (pass)
+- **Uncommitted changes:** cam.ts, lookupServices.ts, lookupApiSlice.ts, camSlice.ts, this plan file
+- **Environment state:** On branch issue-259-phase-term
+
+## Failed Approaches
+<!-- Carried over from the Angular task to avoid repeating -->
+
+| What was tried | Why it failed | Date |
+| -------------- | ------------- | ---- |
+| Replace the rootTypes filter with node.category matching in the prelookup | User corrected: don't touch the filter, only fix `notAnnotatable` | 2026-03-17 (Angular) |
+
+## Files Modified
+
+| File | Action | Status |
+| ---- | ------ | ------ |
+| `src/features/gocam/models/cam.ts` | Add `PHASE_CATEGORIES` set | Done |
+| `src/features/search/services/lookupServices.ts` | `mapGOlrResponse` closureIds + allowNotAnnotatable | Done |
+| `src/features/search/slices/lookupApiSlice.ts` | Pass `closureIds` to `mapGOlrResponse` | Done |
+| `src/features/gocam/slices/camSlice.ts` | `makeSelectModelTerms`/`nodeToOption` notAnnotatable logic | Done |
+
+## Blockers
+- None currently
+
+## Notes
+- `notAnnotatable` has inverted-sounding logic: `true` = annotatable, `false` = do-not-annotate. Autocomplete: `doNotAnnotate = option.notAnnotatable === false`.
+- The `happens during` insert-menu item only targets `BIOLOGICAL_PHASE`, so an inserted node's `searchClosureIds` = `['GO:0044848']`. The other two stage types matter mainly for the prelookup `isPhase` check on model nodes loaded from the backend.
+- Angular's `existence_overlaps` / `existence_starts_and_ends_during` relations **do not exist** in this repo (only `happens_during`), so there's nothing to port for them.
+- No tests added unless requested.
+
+## Additional Context (Claude)
+- The two consumers share the same category context (`closureIds`/`rootTypeIds`) that's already threaded from `EntityRow` → `TermAutocomplete`; the entire change is making those two functions read the phase category. No new props or plumbing.

--- a/.plans/feature/phase-terms-extensions.md
+++ b/.plans/feature/phase-terms-extensions.md
@@ -79,6 +79,8 @@ The bypass keys on the **field's** `closureIds`, not on the term. A phase term `
 | `src/features/search/services/lookupServices.ts` | `mapGOlrResponse` closureIds + allowNotAnnotatable | Done |
 | `src/features/search/slices/lookupApiSlice.ts` | Pass `closureIds` to `mapGOlrResponse` | Done |
 | `src/features/gocam/slices/camSlice.ts` | `makeSelectModelTerms`/`nodeToOption` notAnnotatable logic | Done |
+| `tests/features/search/services/lookupServices.test.ts` | +5 tests: phase/stage bypass in `mapGOlrResponse` | Done |
+| `tests/features/gocam/slices/camSlice.test.ts` | +4 tests: phase/stage bypass in `makeSelectModelTerms` | Done |
 
 ## Blockers
 - None currently
@@ -87,7 +89,7 @@ The bypass keys on the **field's** `closureIds`, not on the term. A phase term `
 - `notAnnotatable` has inverted-sounding logic: `true` = annotatable, `false` = do-not-annotate. Autocomplete: `doNotAnnotate = option.notAnnotatable === false`.
 - The `happens during` insert-menu item only targets `BIOLOGICAL_PHASE`, so an inserted node's `searchClosureIds` = `['GO:0044848']`. The other two stage types matter mainly for the prelookup `isPhase` check on model nodes loaded from the backend.
 - Angular's `existence_overlaps` / `existence_starts_and_ends_during` relations **do not exist** in this repo (only `happens_during`), so there's nothing to port for them.
-- No tests added unless requested.
+- Tests added (on request): cover both paths — type-ahead (`mapGOlrResponse`) and prelookup (`makeSelectModelTerms`) — including the key "phase term stays blocked in a non-phase field" case and all three stage types.
 
 ## Additional Context (Claude)
 - The two consumers share the same category context (`closureIds`/`rootTypeIds`) that's already threaded from `EntityRow` → `TermAutocomplete`; the entire change is making those two functions read the phase category. No new props or plumbing.

--- a/src/features/gocam/models/cam.ts
+++ b/src/features/gocam/models/cam.ts
@@ -38,6 +38,17 @@ export enum NodeType {
   PROTEIN_CONTAINING_COMPLEX = RootTypes.PROTEIN_CONTAINING_COMPLEX,
 }
 
+/**
+ * Phase/stage root types. Terms under these are marked `gocheck_do_not_annotate`
+ * but are allowed in extension fields whose range is a phase/stage (e.g. `happens during`).
+ * When a field's closure context includes one of these, do-not-annotate filtering is bypassed.
+ */
+export const PHASE_CATEGORIES = new Set<string>([
+  RootTypes.BIOLOGICAL_PHASE,
+  RootTypes.UBERON_STAGE,
+  RootTypes.PLANT_STAGE,
+])
+
 export enum Aspect {
   MOLECULAR_FUNCTION = 'F',
   BIOLOGICAL_PROCESS = 'P',

--- a/src/features/gocam/slices/camSlice.ts
+++ b/src/features/gocam/slices/camSlice.ts
@@ -1,6 +1,7 @@
 import type { PayloadAction } from '@reduxjs/toolkit'
 import { createSlice, createSelector } from '@reduxjs/toolkit'
 import type { GraphModel, Activity } from '../models/cam'
+import { PHASE_CATEGORIES } from '../models/cam'
 import type { GOlrResponse } from '@/features/search/models/search'
 
 interface CamState {
@@ -64,6 +65,9 @@ export const makeSelectModelTerms = () =>
     ],
     (model, rootTypeIds, excludeRootTypeIds): GOlrResponse[] => {
       if (!model) return []
+      // When the field's range is a phase/stage (e.g. `happens during`), allow
+      // do-not-annotate terms; otherwise phase terms stay blocked outside their fields.
+      const allowNotAnnotatable = rootTypeIds.some(id => PHASE_CATEGORIES.has(id))
       const seen = new Set<string>()
       const results: GOlrResponse[] = []
       for (const activity of model.activities) {
@@ -81,7 +85,8 @@ export const makeSelectModelTerms = () =>
           )
             continue
           seen.add(node.id)
-          results.push(nodeToOption(node))
+          const isPhase = node.rootTypes.some(rt => PHASE_CATEGORIES.has(rt))
+          results.push(nodeToOption(node, allowNotAnnotatable || !isPhase))
         }
       }
       return results
@@ -156,7 +161,10 @@ export const selectModelWiths = createSelector(
   }
 )
 
-function nodeToOption(node: { id: string; label: string }): GOlrResponse {
+function nodeToOption(
+  node: { id: string; label: string },
+  notAnnotatable = true
+): GOlrResponse {
   return {
     id: node.id,
     label: node.label,
@@ -166,7 +174,7 @@ function nodeToOption(node: { id: string; label: string }): GOlrResponse {
     replacedBy: '',
     rootTypes: [],
     xref: '',
-    notAnnotatable: true,
+    notAnnotatable,
     neighborhoodGraphJson: '',
   }
 }

--- a/src/features/search/services/lookupServices.ts
+++ b/src/features/search/services/lookupServices.ts
@@ -1,5 +1,6 @@
 import { v4 as uuidv4 } from 'uuid'
 import type { Entity, Evidence } from '@/features/gocam/models/cam'
+import { PHASE_CATEGORIES } from '@/features/gocam/models/cam'
 import type { Group } from '@/features/users/models/contributor'
 import type { GOlrResponse, AnnotationsResponse } from '../models/search'
 import { ENVIRONMENT } from '@/@noctua.core/data/constants'
@@ -36,8 +37,11 @@ export const formatSolrQueryString = (query: string): string => {
   return formattedQuery
 }
 
-export const mapGOlrResponse = (response: any): GOlrResponse[] => {
+export const mapGOlrResponse = (response: any, closureIds?: string[]): GOlrResponse[] => {
   const docs = response.response.docs
+  // When the search field's range is a phase/stage (e.g. `happens during`), allow
+  // do-not-annotate terms — they are valid extension targets there.
+  const allowNotAnnotatable = closureIds?.some(id => PHASE_CATEGORIES.has(id))
 
   return docs.map((item: any) => {
     let xref
@@ -56,7 +60,7 @@ export const mapGOlrResponse = (response: any): GOlrResponse[] => {
       rootTypes: makeEntitiesArray(item.isa_closure, item.isa_closure_label),
       xref: xref,
       neighborhoodGraphJson: item.neighborhood_graph_json,
-      notAnnotatable: !item.subset?.includes('gocheck_do_not_annotate'),
+      notAnnotatable: allowNotAnnotatable || !item.subset?.includes('gocheck_do_not_annotate'),
     } as GOlrResponse
   })
 }

--- a/src/features/search/slices/lookupApiSlice.ts
+++ b/src/features/search/slices/lookupApiSlice.ts
@@ -112,7 +112,7 @@ const lookupApi = apiService
             const response = await createJsonpScript(url)
 
             return {
-              data: mapGOlrResponse(response),
+              data: mapGOlrResponse(response, closureIds),
             }
           } catch (error) {
             return {

--- a/tests/features/gocam/slices/camSlice.test.ts
+++ b/tests/features/gocam/slices/camSlice.test.ts
@@ -10,6 +10,7 @@ import camReducer, {
   makeSelectModelTerms,
 } from '@/features/gocam/slices/camSlice'
 import type { Edge, Evidence, GraphModel } from '@/features/gocam/models/cam'
+import { RootTypes } from '@/features/gocam/models/cam'
 import {
   buildActivity,
   buildEdgeWithEvidence,
@@ -320,5 +321,53 @@ describe('camSlice makeSelectModelTerms', () => {
     const select1 = makeSelectModelTerms()
     const select2 = makeSelectModelTerms()
     expect(select1).not.toBe(select2)
+  })
+})
+
+describe('camSlice makeSelectModelTerms — phase/stage do-not-annotate handling', () => {
+  it('marks ordinary model terms annotatable (notAnnotatable=true) in a non-phase field', () => {
+    const bp = buildNode('GO:0008151', 'cell death', [RootTypes.BIOLOGICAL_PROCESS])
+    const a = buildActivity('act-1', [bp])
+    const state = { cam: { ...initial, model: buildModel([a]) } }
+
+    const [opt] = makeSelectModelTerms()(state, [RootTypes.BIOLOGICAL_PROCESS])
+    expect(opt.id).toBe('GO:0008151')
+    expect(opt.notAnnotatable).toBe(true)
+  })
+
+  it('keeps a phase term annotatable when the field range is a phase (happens during)', () => {
+    const phase = buildNode('GO:0044849', 'M phase', [RootTypes.BIOLOGICAL_PHASE])
+    const a = buildActivity('act-1', [phase])
+    const state = { cam: { ...initial, model: buildModel([a]) } }
+
+    const [opt] = makeSelectModelTerms()(state, [RootTypes.BIOLOGICAL_PHASE])
+    expect(opt.id).toBe('GO:0044849')
+    expect(opt.notAnnotatable).toBe(true)
+  })
+
+  it('blocks a phase term (notAnnotatable=false) when it surfaces in a non-phase field', () => {
+    // A phase term is_a biological_process, so its rootTypes include BP and it can
+    // pass the BP-field filter — but it must stay do-not-annotate there.
+    const phaseUnderBp = buildNode('GO:0044849', 'M phase', [
+      RootTypes.BIOLOGICAL_PHASE,
+      RootTypes.BIOLOGICAL_PROCESS,
+    ])
+    const a = buildActivity('act-1', [phaseUnderBp])
+    const state = { cam: { ...initial, model: buildModel([a]) } }
+
+    const [opt] = makeSelectModelTerms()(state, [RootTypes.BIOLOGICAL_PROCESS])
+    expect(opt.id).toBe('GO:0044849')
+    expect(opt.notAnnotatable).toBe(false)
+  })
+
+  it('unlocks for uberon stage and plant stage field ranges too', () => {
+    const uberon = buildNode('UBERON:0000113', 'post-juvenile', [RootTypes.UBERON_STAGE])
+    const plant = buildNode('PO:0007134', 'sporophyte stage', [RootTypes.PLANT_STAGE])
+    const a = buildActivity('act-1', [uberon, plant])
+    const state = { cam: { ...initial, model: buildModel([a]) } }
+
+    const select = makeSelectModelTerms()
+    expect(select(state, [RootTypes.UBERON_STAGE]).find(o => o.id === 'UBERON:0000113')?.notAnnotatable).toBe(true)
+    expect(select(state, [RootTypes.PLANT_STAGE]).find(o => o.id === 'PO:0007134')?.notAnnotatable).toBe(true)
   })
 })

--- a/tests/features/search/services/lookupServices.test.ts
+++ b/tests/features/search/services/lookupServices.test.ts
@@ -5,6 +5,7 @@ import {
   processAnnotationsResponse,
   processHasParticipants,
 } from '@/features/search/services/lookupServices'
+import { RootTypes } from '@/features/gocam/models/cam'
 
 import searchMfFixture from '@tests/fixtures/raw/golr/search-mf.json'
 import searchBpFixture from '@tests/fixtures/raw/golr/search-bp.json'
@@ -104,6 +105,66 @@ describe('mapGOlrResponse', () => {
     for (const r of results) {
       expect(typeof r.notAnnotatable).toBe('boolean')
     }
+  })
+})
+
+// ─── mapGOlrResponse: phase/stage do-not-annotate handling ──────────
+//
+// Phase/stage terms carry `gocheck_do_not_annotate` but are valid extension
+// targets in fields whose range is a phase/stage (e.g. `happens during`). The
+// bypass keys on the *field's* closure context, never on the term itself.
+
+const golrDoc = (id: string, opts: { doNotAnnotate?: boolean } = {}) => ({
+  annotation_class: id,
+  annotation_class_label: `label ${id}`,
+  subset: opts.doNotAnnotate ? ['gocheck_do_not_annotate'] : [],
+  isa_closure: [id],
+  isa_closure_label: [`label ${id}`],
+})
+
+const golrResponse = (docs: ReturnType<typeof golrDoc>[]) => ({ response: { docs } })
+
+describe('mapGOlrResponse — phase/stage do-not-annotate handling', () => {
+  it('marks a do-not-annotate term notAnnotatable=false with no closure context', () => {
+    const [r] = mapGOlrResponse(golrResponse([golrDoc('GO:0044849', { doNotAnnotate: true })]))
+    expect(r.notAnnotatable).toBe(false)
+  })
+
+  it('keeps a do-not-annotate term blocked in a non-phase field (closureIds = BP)', () => {
+    const [r] = mapGOlrResponse(
+      golrResponse([golrDoc('GO:0044849', { doNotAnnotate: true })]),
+      [RootTypes.BIOLOGICAL_PROCESS]
+    )
+    expect(r.notAnnotatable).toBe(false)
+  })
+
+  it('unlocks do-not-annotate terms when closureIds include biological phase (GO:0044848)', () => {
+    const [r] = mapGOlrResponse(
+      golrResponse([golrDoc('GO:0044849', { doNotAnnotate: true })]),
+      [RootTypes.BIOLOGICAL_PHASE]
+    )
+    expect(r.notAnnotatable).toBe(true)
+  })
+
+  it('unlocks for uberon stage and plant stage closures too', () => {
+    const [uberon] = mapGOlrResponse(
+      golrResponse([golrDoc('UBERON:0000113', { doNotAnnotate: true })]),
+      [RootTypes.UBERON_STAGE]
+    )
+    const [plant] = mapGOlrResponse(
+      golrResponse([golrDoc('PO:0007134', { doNotAnnotate: true })]),
+      [RootTypes.PLANT_STAGE]
+    )
+    expect(uberon.notAnnotatable).toBe(true)
+    expect(plant.notAnnotatable).toBe(true)
+  })
+
+  it('leaves ordinary (annotatable) terms notAnnotatable=true even in a phase field', () => {
+    const [r] = mapGOlrResponse(
+      golrResponse([golrDoc('GO:0007049')]),
+      [RootTypes.BIOLOGICAL_PHASE]
+    )
+    expect(r.notAnnotatable).toBe(true)
   })
 })
 


### PR DESCRIPTION
### Issues

- https://github.com/geneontology/noctua-visual-pathway-editor/issues/259

### Changes

- Add `PHASE_CATEGORIES` (biological phase, uberon stage, plant stage)
- Allow `gocheck_do_not_annotate` phase/stage terms in extension fields whose range is a phase/stage (e.g. `happens during`); they stay blocked everywhere else
- Thread the field's closure context through the GOlr response mapping and the model-term selector
- Add unit tests for `camSlice` term selection and `lookupServices` mapping

### Tests

- [ ] In an extension field with a phase/stage range (e.g. `happens during`), confirm phase terms appear and are selectable
- [ ] Confirm phase/stage terms remain blocked in non-phase fields
- [ ] Confirm previously-used model phase terms show in the model-terms dropdown

cc @pgaudet @vanaukenk @kltm @thomaspd
