### PR TITLE
Allow protein complexes as has-input; fix Protein Complex form part label (#270, #275)

### DIFF
--- a/.plans/bugfix/has-input-protein-complex-270.md
+++ b/.plans/bugfix/has-input-protein-complex-270.md
@@ -24,6 +24,14 @@ the two closures. The insert menu also passes only `targetType` (Gene Product).
    together. `lookupApiSlice` ORs closure ids, so both surface. Node creation is
    unchanged: the selected term's class wins.
 
+4. `insertMenuConfig.ts` — added a hidden (`showInMenu: false`) twin has-input item
+   targeting `PROTEIN_CONTAINING_COMPLEX`. The display resolvers (`getDisplayGroup`,
+   `getInsertWeight`, `getRelationRowLabel`) key on `(parent, predicate, targetType)`;
+   a complex input resolves its target to the complex category, which the single
+   Gene-Product item didn't match — so it fell back to the GP card instead of the
+   has-input group (didn't render as an input). The twin groups/weights/labels it as a
+   has input. Mirrors the `enabled by` GP/complex pair. Menu still shows one item.
+
 ## Files
 - src/features/gocam/data/nodeCategories.ts
 - src/features/gocam/data/insertMenuConfig.ts

--- a/.plans/bugfix/has-input-protein-complex-270.md
+++ b/.plans/bugfix/has-input-protein-complex-270.md
@@ -1,0 +1,31 @@
+# Bugfix: GO protein complexes cannot be added as inputs (#270)
+
+## Problem
+`has input` on a molecular function lost the ability to search/add protein complexes
+— only gene products show up. Old code searched a union of Gene Product + Protein
+Complex closures (`category: [GoMolecularEntity, GoProteinContainingComplex]`).
+
+## Root cause
+The has-input term search is scoped by `getSearchClosures`, which collapses a
+multi-type set to a **single** primary category (via `getPrimaryRootType`). Even when
+the range is [Gene Product, Protein Complex] it picks one, so the search never unions
+the two closures. The insert menu also passes only `targetType` (Gene Product).
+
+## Fix (union search for has-input)
+1. `insertMenuConfig.ts` — add optional `searchRootTypes?` to `InsertMenuItem`; set it
+   to `[MOLECULAR_ENTITY, PROTEIN_CONTAINING_COMPLEX]` on the `has input` item.
+2. `EntityRow` + `ActivityTableNode` insert handlers — pass `item.searchRootTypes` (fall
+   back to `[targetType]`) as the new node's search root types.
+3. `getSearchClosures` — made config-driven instead of a hardcoded pair. It maps each
+   root type to its category and drops any category that another present category
+   supersedes via `excludeClosureIds` (chemical excludes gene product, CC excludes
+   complex). What remains is the most-specific category — usually one, but for a union
+   range like has-input it's the two disjoint siblings, whose closures are searched
+   together. `lookupApiSlice` ORs closure ids, so both surface. Node creation is
+   unchanged: the selected term's class wins.
+
+## Files
+- src/features/gocam/data/nodeCategories.ts
+- src/features/gocam/data/insertMenuConfig.ts
+- src/features/gocam/components/forms/EntityRow.tsx
+- src/features/gocam/components/ActivityTableNode.tsx

--- a/.plans/bugfix/protein-complex-default-part-label-275.md
+++ b/.plans/bugfix/protein-complex-default-part-label-275.md
@@ -1,0 +1,22 @@
+# Bugfix: inconsistent part label in Protein Complex create form (#275)
+
+## Problem
+In the Create form for a Protein Complex, the complex was seeded with one default
+gene-product part. That default row was labelled from its category (`Gene Product`),
+while every part added afterwards via the `+` menu was labelled
+`(Protein Complex) has part (GP)` — so the first part looked different from the rest.
+
+## Solution (agreed with reporter on the issue)
+Remove the single default gene product. The complex now starts with no parts and every
+part is added the same way via the row's `+` menu, so they all render with the same
+`(Protein Complex) has part (GP)` label.
+
+## Change
+- `activityTemplates.ts` — `proteinComplexActivity`: the enabled_by ProteinComplex
+  target now has `relations: []` (was one default `has_part → gene product`).
+- `activityTemplates.test.ts` — updated the assertion: the complex starts with zero
+  parts instead of one default has_part GP child.
+
+## Files
+- src/features/gocam/data/activityTemplates.ts
+- tests/features/gocam/data/activityTemplates.test.ts

--- a/src/features/gocam/components/ActivityTableNode.tsx
+++ b/src/features/gocam/components/ActivityTableNode.tsx
@@ -160,7 +160,7 @@ const ActivityTableNode: React.FC<ActivityTableNodeProps> = ({
           showTerm: true,
           title: `Add ${item.label}`,
           termLabel: item.label,
-          termRootTypes: [item.targetType],
+          termRootTypes: item.searchRootTypes ?? [item.targetType],
           gpId: gpNodeId,
           aspect: targetAspect,
           activityType,

--- a/src/features/gocam/components/forms/EntityRow.tsx
+++ b/src/features/gocam/components/forms/EntityRow.tsx
@@ -220,7 +220,7 @@ const EntityRow: React.FC<EntityRowProps> = ({
         predicate: item.predicate,
         nodeType: item.targetType,
         label: item.nodeLabel ?? targetCategory?.label ?? item.targetType,
-        rootTypes: targetCategory?.searchClosureIds ?? [item.targetType],
+        rootTypes: item.searchRootTypes ?? targetCategory?.searchClosureIds ?? [item.targetType],
         aspect: targetCategory?.aspect ?? null,
       })
     )

--- a/src/features/gocam/data/activityTemplates.ts
+++ b/src/features/gocam/data/activityTemplates.ts
@@ -65,9 +65,10 @@ const proteinComplexActivity: TermDescriptor = {
         category: complexCat,
         required: true,
         skipEvidenceCheck: true,
-        relations: [
-          { predicateId: Relations.HAS_PART, target: { category: gpCat, canDelete: true } },
-        ],
+        // No default gene product — every part is added via the row's `+` menu, so all
+        // parts render with the same `(Protein Complex) has part (GP)` label instead of
+        // the lone default part looking different from the rest. (#275)
+        relations: [],
       },
     },
     {

--- a/src/features/gocam/data/insertMenuConfig.ts
+++ b/src/features/gocam/data/insertMenuConfig.ts
@@ -164,6 +164,21 @@ export const canInsertEntity: Record<string, InsertMenuItem[]> = {
       cardinality: Cardinality.ONE_TO_MANY,
       displayGroup: DisplayGroup.MF_INPUT,
     },
+    // A has input value may be a protein complex. The menu shows the single item above
+    // (whose search spans both); this hidden twin exists so a complex input is grouped,
+    // weighted and labelled as a has input — its target resolves to the complex category,
+    // which the display resolvers key on. Mirrors the enabled by GP/complex pair.
+    {
+      label: 'has input',
+      nodeLabel: 'has input (Gene Product/Protein Complex)',
+      rangeLabel: 'Gene Product/Protein Complex',
+      targetType: RootTypes.PROTEIN_CONTAINING_COMPLEX,
+      predicate: predicate(Relations.HAS_INPUT),
+      showInMenu: false,
+      weight: 5,
+      cardinality: Cardinality.ONE_TO_MANY,
+      displayGroup: DisplayGroup.MF_INPUT,
+    },
     {
       label: 'happens during',
       nodeLabel: 'happens during (Biological Phase/Stage/Plant Stage)',

--- a/src/features/gocam/data/insertMenuConfig.ts
+++ b/src/features/gocam/data/insertMenuConfig.ts
@@ -53,6 +53,12 @@ export interface InsertMenuItem {
   nodeLabel?: string
   rangeLabel: string
   targetType: string
+  /**
+   * Root-type closures the term search should span, when the relation accepts more
+   * than the single `targetType`. `has input` accepts a Gene Product OR a Protein
+   * Complex, so its search unions both closures. Defaults to `[targetType]`.
+   */
+  searchRootTypes?: string[]
   predicate: { id: string; label: string }
   showInMenu: boolean
   weight: number
@@ -151,6 +157,7 @@ export const canInsertEntity: Record<string, InsertMenuItem[]> = {
       nodeLabel: 'has input (Gene Product/Protein Complex)',
       rangeLabel: 'Gene Product/Protein Complex',
       targetType: RootTypes.MOLECULAR_ENTITY,
+      searchRootTypes: [RootTypes.MOLECULAR_ENTITY, RootTypes.PROTEIN_CONTAINING_COMPLEX],
       predicate: predicate(Relations.HAS_INPUT),
       showInMenu: true,
       weight: 5,

--- a/src/features/gocam/data/nodeCategories.ts
+++ b/src/features/gocam/data/nodeCategories.ts
@@ -194,21 +194,37 @@ export const getPrimaryRootType = (rootTypes: string[]): string | null => {
 
 /**
  * Resolve the term-search closure filter (include + exclude) for a node from its
- * *primary* category — never the raw root-type set. Minerva returns a node's full
- * inferred type set, so a gene product carries both MOLECULAR_ENTITY (CHEBI:33695)
- * and its parent CHEMICAL_ENTITY (CHEBI:24431). Searching the raw set would include
- * chemicals; scoping to the primary category (gene product → search CHEBI:33695 only)
- * matches the activity-form template path, which searches a single category.
- * Falls back to the raw root types when the primary type has no known category.
+ * categories — never the raw root-type set. Minerva returns a node's full inferred
+ * type set, so a gene product carries both MOLECULAR_ENTITY (CHEBI:33695) and its
+ * parent CHEMICAL_ENTITY (CHEBI:24431); searching the raw set would surface chemicals.
+ *
+ * A category declares which broader sibling it supersedes via `excludeClosureIds`
+ * (chemical excludes gene product, cellular component excludes protein complex). We
+ * drop any present category that another present category excludes — that leaves the
+ * most-specific one(s). Usually that's a single category. For a curated union range
+ * like `has input` (gene product OR protein complex), it's several disjoint siblings,
+ * and all their closures are searched together (OR'd downstream). Falls back to the
+ * raw root types when none resolve to a known category. (#267, #270)
  */
 export const getSearchClosures = (
   rootTypes: string[]
 ): { closureIds: string[]; excludeClosureIds?: string[] } => {
-  const primary = getPrimaryRootType(rootTypes)
-  const category = primary ? getNodeCategory(primary) : undefined
+  const categories = rootTypes
+    .map(getNodeCategory)
+    .filter((c): c is AnyCategory & NodeCategory => Boolean(c))
+  if (categories.length === 0) return { closureIds: rootTypes }
+
+  const presentIds = new Set(categories.map(c => c.id))
+  const specific = categories.filter(
+    c => !(c.excludeClosureIds ?? []).some(id => presentIds.has(id))
+  )
+  const chosen = specific.length > 0 ? specific : categories
+
+  const closureIds = [...new Set(chosen.flatMap(c => c.searchClosureIds))]
+  const excludeClosureIds = [...new Set(chosen.flatMap(c => c.excludeClosureIds ?? []))]
   return {
-    closureIds: category?.searchClosureIds ?? rootTypes,
-    excludeClosureIds: category?.excludeClosureIds,
+    closureIds,
+    excludeClosureIds: excludeClosureIds.length > 0 ? excludeClosureIds : undefined,
   }
 }
 

--- a/tests/features/gocam/data/activityTemplates.test.ts
+++ b/tests/features/gocam/data/activityTemplates.test.ts
@@ -82,13 +82,10 @@ describe('createActivityTemplate("proteinComplex")', () => {
     )
   })
 
-  it('the enabled_by target is a ProteinComplex with a has_part GP child', () => {
+  it('the enabled_by target is a ProteinComplex with no default part — all parts added via + (#275)', () => {
     const enabledBy = root.relations.find(r => r.predicate.id === Relations.ENABLED_BY)!
     expect(enabledBy.target.category).toBe(RootTypes.PROTEIN_CONTAINING_COMPLEX)
-    expect(enabledBy.target.relations).toHaveLength(1)
-    expect(enabledBy.target.relations[0].predicate.id).toBe(Relations.HAS_PART)
-    expect(enabledBy.target.relations[0].target.category).toBe(RootTypes.MOLECULAR_ENTITY)
-    expect(enabledBy.target.relations[0].target.canDelete).toBe(true)
+    expect(enabledBy.target.relations).toHaveLength(0)
   })
 })
 

--- a/tests/features/gocam/data/insertMenuConfig.test.ts
+++ b/tests/features/gocam/data/insertMenuConfig.test.ts
@@ -98,4 +98,24 @@ describe('has input — Gene Product or Protein Complex (#270)', () => {
       )
     ).toBe('has input (Gene Product/Protein Complex)')
   })
+
+  // pgaudet on #270: proteins and protein complexes are allowed, not chemicals
+  // (chemicals go via the chemical form); inputs cannot be nested.
+  it('never targets a chemical — its search spans only proteins and complexes', () => {
+    const hasInput = getInsertMenuItems(RootTypes.MOLECULAR_FUNCTION).filter(
+      i => i.predicate.id === Relations.HAS_INPUT
+    )
+    for (const item of hasInput) {
+      const roots = item.searchRootTypes ?? [item.targetType]
+      expect(roots).not.toContain(RootTypes.CHEMICAL_ENTITY)
+      expect(roots).toEqual([RootTypes.MOLECULAR_ENTITY, RootTypes.PROTEIN_CONTAINING_COMPLEX])
+    }
+  })
+
+  it('does not let a has input value (protein or complex) take another has input — inputs cannot be nested', () => {
+    const fromGeneProduct = getInsertMenuItems(RootTypes.MOLECULAR_ENTITY)
+    const fromComplex = getInsertMenuItems(RootTypes.PROTEIN_CONTAINING_COMPLEX)
+    expect(fromGeneProduct.some(i => i.predicate.id === Relations.HAS_INPUT)).toBe(false)
+    expect(fromComplex.some(i => i.predicate.id === Relations.HAS_INPUT)).toBe(false)
+  })
 })

--- a/tests/features/gocam/data/insertMenuConfig.test.ts
+++ b/tests/features/gocam/data/insertMenuConfig.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest'
-import { getInsertMenuItems } from '@/features/gocam/data/insertMenuConfig'
+import {
+  getInsertMenuItems,
+  getDisplayGroup,
+  getInsertWeight,
+  getRelationRowLabel,
+  DisplayGroup,
+} from '@/features/gocam/data/insertMenuConfig'
 import { RootTypes } from '@/features/gocam/models/cam'
 import { Relations } from '@/@noctua.core/models/relations'
 
@@ -39,5 +45,57 @@ describe('getInsertMenuItems — protein-complex recursion suppression', () => {
       Relations.PART_OF
     )
     expect(items.some(i => i.targetType === RootTypes.BIOLOGICAL_PROCESS)).toBe(true)
+  })
+})
+
+describe('has input — Gene Product or Protein Complex (#270)', () => {
+  it('shows a single has input menu item whose search spans gene product + protein complex', () => {
+    const hasInput = getInsertMenuItems(RootTypes.MOLECULAR_FUNCTION).filter(
+      i => i.predicate.id === Relations.HAS_INPUT
+    )
+    expect(hasInput).toHaveLength(1)
+    expect(hasInput[0].searchRootTypes).toEqual([
+      RootTypes.MOLECULAR_ENTITY,
+      RootTypes.PROTEIN_CONTAINING_COMPLEX,
+    ])
+  })
+
+  it('groups a protein-complex has input under the has-input card (MF_INPUT), not GP', () => {
+    expect(
+      getDisplayGroup(
+        RootTypes.MOLECULAR_FUNCTION,
+        Relations.HAS_INPUT,
+        RootTypes.PROTEIN_CONTAINING_COMPLEX
+      )
+    ).toBe(DisplayGroup.MF_INPUT)
+    // parity with the gene-product input
+    expect(
+      getDisplayGroup(RootTypes.MOLECULAR_FUNCTION, Relations.HAS_INPUT, RootTypes.MOLECULAR_ENTITY)
+    ).toBe(DisplayGroup.MF_INPUT)
+  })
+
+  it('weights a protein-complex has input the same as a gene-product has input', () => {
+    const gp = getInsertWeight(
+      RootTypes.MOLECULAR_FUNCTION,
+      Relations.HAS_INPUT,
+      RootTypes.MOLECULAR_ENTITY
+    )
+    const complex = getInsertWeight(
+      RootTypes.MOLECULAR_FUNCTION,
+      Relations.HAS_INPUT,
+      RootTypes.PROTEIN_CONTAINING_COMPLEX
+    )
+    expect(complex).toBe(gp)
+    expect(complex).toBeLessThan(Number.POSITIVE_INFINITY)
+  })
+
+  it('labels a protein-complex has input row as a has input', () => {
+    expect(
+      getRelationRowLabel(
+        RootTypes.MOLECULAR_FUNCTION,
+        Relations.HAS_INPUT,
+        RootTypes.PROTEIN_CONTAINING_COMPLEX
+      )
+    ).toBe('has input (Gene Product/Protein Complex)')
   })
 })

--- a/tests/features/gocam/data/nodeCategories.test.ts
+++ b/tests/features/gocam/data/nodeCategories.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest'
 import {
   getNodeCategory,
   getPrimaryRootType,
+  getSearchClosures,
   molecularFunction,
   biologicalProcess,
   cellularComponent,
@@ -106,5 +107,60 @@ describe('getPrimaryRootType (most-specific-first resolution)', () => {
 
   it('returns null for an empty root-type set', () => {
     expect(getPrimaryRootType([])).toBeNull()
+  })
+})
+
+describe('getSearchClosures (term-search closure resolution)', () => {
+  it('unions gene product + protein complex for a has-input target (#270)', () => {
+    const { closureIds, excludeClosureIds } = getSearchClosures([
+      RootTypes.MOLECULAR_ENTITY,
+      RootTypes.PROTEIN_CONTAINING_COMPLEX,
+    ])
+    // Neither category excludes the other, so both closures are searched (OR'd downstream).
+    expect(new Set(closureIds)).toEqual(
+      new Set([RootTypes.MOLECULAR_ENTITY, RootTypes.PROTEIN_CONTAINING_COMPLEX])
+    )
+    expect(closureIds).toHaveLength(2)
+    expect(excludeClosureIds).toBeUndefined()
+  })
+
+  it('narrows a Minerva gene-product set to gene product only, dropping the parent chemical (#267)', () => {
+    const { closureIds, excludeClosureIds } = getSearchClosures([
+      RootTypes.MOLECULAR_ENTITY,
+      RootTypes.CHEMICAL_ENTITY,
+    ])
+    expect(closureIds).toEqual([RootTypes.MOLECULAR_ENTITY])
+    expect(excludeClosureIds).toBeUndefined()
+  })
+
+  it('excludes gene products from a bare chemical search', () => {
+    const { closureIds, excludeClosureIds } = getSearchClosures([RootTypes.CHEMICAL_ENTITY])
+    expect(closureIds).toEqual([RootTypes.CHEMICAL_ENTITY])
+    expect(excludeClosureIds).toEqual([RootTypes.MOLECULAR_ENTITY])
+  })
+
+  it('narrows a Minerva complex set to complex only, dropping the parent cellular component', () => {
+    const { closureIds } = getSearchClosures([
+      RootTypes.PROTEIN_CONTAINING_COMPLEX,
+      RootTypes.CELLULAR_COMPONENT,
+    ])
+    expect(closureIds).toEqual([RootTypes.PROTEIN_CONTAINING_COMPLEX])
+  })
+
+  it('excludes protein complexes from a bare cellular-component search', () => {
+    const { closureIds, excludeClosureIds } = getSearchClosures([RootTypes.CELLULAR_COMPONENT])
+    expect(closureIds).toEqual([RootTypes.CELLULAR_COMPONENT])
+    expect(excludeClosureIds).toEqual([RootTypes.PROTEIN_CONTAINING_COMPLEX])
+  })
+
+  it('returns a single-category closure unchanged', () => {
+    const { closureIds, excludeClosureIds } = getSearchClosures([RootTypes.MOLECULAR_ENTITY])
+    expect(closureIds).toEqual([RootTypes.MOLECULAR_ENTITY])
+    expect(excludeClosureIds).toBeUndefined()
+  })
+
+  it('falls back to the raw root types when none map to a known category', () => {
+    const { closureIds } = getSearchClosures(['XYZ:999'])
+    expect(closureIds).toEqual(['XYZ:999'])
   })
 })

--- a/tests/features/gocam/data/nodeCategories.test.ts
+++ b/tests/features/gocam/data/nodeCategories.test.ts
@@ -164,3 +164,27 @@ describe('getSearchClosures (term-search closure resolution)', () => {
     expect(closureIds).toEqual(['XYZ:999'])
   })
 })
+
+describe('has input range — proteins and protein complexes, not chemicals (#270)', () => {
+  // pgaudet on #270: "Proteins and protein complexes are allowed, not chemicals, these
+  // should be added via the chemical form" and "there can be multiple inputs".
+  it('accepts a gene product (a protein, not a complex) and a protein complex, but not a chemical', () => {
+    const range = molecularFunction.hasInput.range
+    expect(range).toContain(RootTypes.MOLECULAR_ENTITY) // gene product = a protein, not a complex
+    expect(range).toContain(RootTypes.PROTEIN_CONTAINING_COMPLEX)
+    expect(range).not.toContain(RootTypes.CHEMICAL_ENTITY)
+  })
+
+  it('allows multiple inputs (multivalued, not nested)', () => {
+    expect(molecularFunction.hasInput.multivalued).toBe(true)
+  })
+
+  it('search spans the protein closure (non-complex) and the complex closure, never chemicals', () => {
+    const { closureIds } = getSearchClosures(molecularFunction.hasInput.range)
+    // a protein that is NOT a protein complex still resolves — gene products are searchable
+    expect(closureIds).toContain(RootTypes.MOLECULAR_ENTITY)
+    expect(closureIds).toContain(RootTypes.PROTEIN_CONTAINING_COMPLEX)
+    // chemicals are added via the chemical form, so they must never be in the has-input search
+    expect(closureIds).not.toContain(RootTypes.CHEMICAL_ENTITY)
+  })
+})


### PR DESCRIPTION
### Issues

- https://github.com/geneontology/noctua-visual-pathway-editor/issues/270
- https://github.com/geneontology/noctua-visual-pathway-editor/issues/275

### Changes

- **has input protein complexes (#270):** restored the union term search over
  Gene Product **or** Protein Complex closures on a molecular function's `has input`.
  `getSearchClosures` is now config-driven — it maps each root type to its category
  and drops any category another present category supersedes via `excludeClosureIds`,
  leaving the most-specific one(s): one category normally, or both disjoint siblings
  for a union range. Added optional `searchRootTypes?` to `InsertMenuItem` (unioning
  `[MOLECULAR_ENTITY, PROTEIN_CONTAINING_COMPLEX]` on `has input`), threaded through
  `EntityRow` and `ActivityTableNode`. Added a hidden twin `has input` item targeting
  the complex category so a complex input is grouped/weighted/labelled as a `has input`
  (mirrors the existing `enabled by` GP/complex pair).
- **Protein Complex form part label (#275):** removed the single default gene-product
  part so the complex starts with no parts; every part is now added the same way via
  the row's `+` menu and shares the `(Protein Complex) has part (GP)` label.
- **Tests:** updated `nodeCategories`, `insertMenuConfig`, and `activityTemplates` specs.

### Tests

- [ ] On a molecular function, open the `has input` term search → both gene products (UniProtKB etc.) and protein complexes appear and are selectable.
- [ ] Add a protein complex as `has input` → it renders grouped under `has input` (not as a separate card), labelled `has input (Gene Product/Protein Complex)`.
- [ ] Add a gene product as `has input` → still works as before.
- [ ] Open the Create form for a Protein Complex → it starts with no default part.
- [ ] Add parts via the `+` menu → every part reads `(Protein Complex) has part (GP)` with no odd first row.

cc @pgaudet @vanaukenk @kltm @thomaspd
