### PR TITLE
Show annotation extensions in annotation search results (#286)

### DIFF
--- a/src/features/gocam/components/forms/SearchAnnotations.tsx
+++ b/src/features/gocam/components/forms/SearchAnnotations.tsx
@@ -206,6 +206,14 @@ const SearchAnnotations: React.FC<SearchAnnotationsProps> = ({
                         </td>
                         <td className="break-words px-2.5 py-2 align-middle">
                           {ev.evidenceCode.label}
+                          {ev.evidenceExts?.map((ext, i) => (
+                            <div key={`${ext.term.id}-${i}`} className="text-[11px] text-gray-500">
+                              <span className="font-semibold">Ext:</span>{' '}
+                              {ext.relations
+                                .map(relation => `${relation.label} : ${ext.term.label}`)
+                                .join(', ')}
+                            </div>
+                          ))}
                         </td>
                         <td className="break-words px-2.5 py-2 align-middle text-gray-700">
                           {ev.reference}

--- a/src/features/gocam/models/cam.ts
+++ b/src/features/gocam/models/cam.ts
@@ -76,6 +76,15 @@ export interface GraphNode {
   comments?: string[];
 }
 
+/**
+ * An annotation extension on a GOlr annotation — one extension target term plus
+ * the relation(s) pointing at it (e.g. `has input` : `histone H3`).
+ */
+export interface EvidenceExt {
+  term: Entity;
+  relations: Entity[];
+}
+
 export interface Evidence {
   uid: string;
   evidenceCode: Entity;
@@ -87,6 +96,8 @@ export interface Evidence {
   date?: string;
   /** Comments annotated on the evidence individual — i.e. reference comments (#231). */
   comments?: string[];
+  /** Annotation extensions from a GOlr annotation lookup, when there are any (#286). */
+  evidenceExts?: EvidenceExt[];
 }
 
 export interface Edge {

--- a/src/features/search/services/lookupServices.ts
+++ b/src/features/search/services/lookupServices.ts
@@ -102,7 +102,7 @@ export const processAnnotationsResponse = (response: any): AnnotationsResponse[]
 
     if (doc.annotation_extension_json) {
       try {
-        const extJsons = Array.isArray(doc.annotation_extension_json)
+        const extJsons: any[] = Array.isArray(doc.annotation_extension_json)
           ? doc.annotation_extension_json.map((ext: string) => JSON.parse(ext))
           : [JSON.parse(doc.annotation_extension_json)]
 


### PR DESCRIPTION
### Issues

- https://github.com/geneontology/noctua-visual-pathway-editor/issues/286

### Changes

- Annotation extensions (e.g. `has input : histone H3`) show again in the **Search Annotations** results, on a small `Ext:` line under each evidence code.
- `processAnnotationsResponse` already parsed `annotation_extension_json` onto `evidence.evidenceExts`, but `Evidence` had no such field, so the parsed extensions were dropped and never rendered. Added an `EvidenceExt` model (extension `term` + its `relations`) and the optional `evidenceExts` field on `Evidence` (#286).
- An extension with multiple relations renders them comma-separated as `relation : term`.

### Tests

- Test checklist: https://github.com/geneontology/noctua-visual-pathway-editor/issues/286#issuecomment-5202128244

cc @ValWood @pgaudet @vanaukenk @kltm @thomaspd
